### PR TITLE
Added additional error handling options for delete and clean + some fixes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,10 @@ The `gitscconf.json` file contains a section for the delete command, allowing yo
 - `onTicketNotFound` - determines what action to take in the event that the Shortcut ticket corresponding to the branch cannot be found, possible values include:
   - `abort` - cancel deletion. For the `clean` command, this means stopping on the first branch with a missing Shortcut ticket. This is the default for `delete`.
   - `delete` - proceed with the delete anyway, the user will have one last chance to change their mind at the y/n prompt, unless `prompt` is turned off
-  - `skip` - skip the current branch; for `delete` this means ending execution (NOOP); the `clean` command will move on to attempt the delete the next branch, if there is another. This is the default for `clean`.
+  - `skip` - skip the current branch; for `delete` this means ending execution (NOOP); the `clean` command will move on to attempt the delete the next
+    branch, if there is another. This is the default for `clean`.
+- `onNotFullyMerged` - determines what action to take in the event that a delete receives a "error: The branch '[branch name]' is not fully merged." response. Possible values are `abort`, `delete`, or `skip`. In this case, the `delete` value will re-attempt the delete with force.
+- `onError` - a catch-all for errors other than the mentioned 'not fully merged' error. Possible values are: `abort`, `delete`, or `skip`, with identical behavior to `onNotFullyMerged`. Open an issue if more specific/tailored behavior is desired for a certain kind of error.
 - `prompt` - boolean, whether to prompt the user before deleting the branch (default: `true`); note: validation will still occur if `prompt` is `false`.
 - `remote` - whether to delete remote branches in addition to local (default: `false`)
 - `filters`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-sc-cli",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "A CLI tool that combines your git and Shortcut workflows. Search for Shortcut tickets, make branches, clean up your local branch list, etc.",
   "main": "index.js",
   "scripts": {},

--- a/src/app.js
+++ b/src/app.js
@@ -192,7 +192,7 @@ function handleTicketNotFound(onTicketNotFound, storyId) {
       return NOTFOUND_ABORT;
     case "delete":
       wrapLog(
-        `${commonCopy} proceeding with branch deletion due to configured 'onStoryNotFound' value`,
+        `${commonCopy} proceeding with branch deletion due to configured 'onTicketNotFound' value`,
         "warn"
       );
       return NOTFOUND_DELETE;

--- a/src/config.js
+++ b/src/config.js
@@ -45,14 +45,18 @@ const deleteBranchFilterSchema = Joi.object({
     .min(1),
 });
 
+const badResultHandlerSchema = Joi.string()
+  .valid("abort", "delete", "skip")
+  .insensitive()
+  .required();
+
 const purgeSchema = Joi.object({
   force: Joi.boolean(),
   remote: Joi.boolean(),
   filters: deleteBranchFilterSchema,
-  onTicketNotFound: Joi.string()
-    .valid("abort", "delete", "skip")
-    .insensitive()
-    .required(),
+  onTicketNotFound: badResultHandlerSchema,
+  onNotFullyMerged: badResultHandlerSchema,
+  onError: badResultHandlerSchema,
   prompt: Joi.boolean(),
 });
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 export const VERSION_MAJOR = 2;
-export const VERSION_MINOR = 0;
+export const VERSION_MINOR = 1;
 export const VERSION_PATCH = 1;
 export const PROGRAM_VERSION = `${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}`;
 export const SEMVER_REGEX = /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/;
@@ -59,6 +59,8 @@ export const DEFAULT_OPTIONS = {
     force: false,
     remote: false,
     onTicketNotFound: "abort",
+    onNotFullyMerged: "abort",
+    onError: "abort",
     filters: structuredClone(branchDeletionFilters),
     prompt: true,
   },
@@ -66,6 +68,8 @@ export const DEFAULT_OPTIONS = {
     force: false,
     remote: false,
     onTicketNotFound: "skip",
+    onNotFullyMerged: "skip",
+    onError: "skip",
     filters: structuredClone(branchDeletionFilters),
     prompt: true,
   },

--- a/src/git-lib/git-client.js
+++ b/src/git-lib/git-client.js
@@ -121,7 +121,13 @@ export default class GitClient {
       );
 
       // bail out early - there was an error and no handler was provided, or handler didn't exit
-      if (!result.success || remoteOnly) return result;
+      // if the remote doesn't exist, it's not much of a problem
+      if (
+        remoteOnly ||
+        (!result.success &&
+          !result.output.includes("remote ref does not exist"))
+      )
+        return result;
     }
 
     // it's safe to overwrite result here - the output will contain the necessary context to debug

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,7 +175,7 @@ export const multiSelectionPrompt = (
 export const extractStoryIdFromBranchName = (branchName, branchNameRegex) => {
   const result = branchName.match(branchNameRegex);
 
-  return result?.groups.ticketId;
+  return result?.groups?.ticketId;
 };
 
 export const underline = (str, customLength = null) =>


### PR DESCRIPTION
PR addresses several issues: 

1. The following error message is far too common: 

> Error: Command failed: git branch -d branch name
error: The branch 'branch name' is not fully merged.
If you are sure you want to delete it, run 'git branch -D branch name'.

For organizations who do a squash merge on pull requests, a branch's remote commit id will mismatch from the local commit id, resulting in this error. `onNotFullyMerged` is added to address this and allow users to determine if they care about this error. 

2. Many other possible errors can result in a git branch delete so the generic `onError` is added to address this 

3. Attempting to delete a remote branch, but then receiving an error saying the remote branch doesn't exist, shouldn't result in the delete command failing. 

4. There was no handling of cases where the ticket id couldn't be parsed from a branch name, resulting in access of `undefined` variable.

5. There was no way to cancel an entire `git-sc clean` command without canceling each individual resulting delete command. Added support for ^C.  